### PR TITLE
feat(distill): survive parent exit on shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bench/results/
 # Vault (local content)
 .napkin/
 thread-draft.md
+package-lock.json

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -5,6 +5,12 @@ import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
+// Process-level guards for SIGHUP handler
+let sighupRegistered = false;
+let sighupSpawned = false;
+let latestCtx: any = null;
+let latestConfig: DistillConfig | null = null;
+
 interface DistillConfig {
   enabled: boolean;
   intervalMinutes: number;
@@ -38,6 +44,11 @@ function findVaultPath(cwd: string): string | null {
     }
     dir = path.dirname(dir);
   }
+  // Fallback: check $HOME/.napkin (vault may not be under cwd's tree)
+  const homeNapkin = path.join(os.homedir(), ".napkin");
+  if (fs.existsSync(homeNapkin)) {
+    return homeNapkin;
+  }
   return null;
 }
 
@@ -55,6 +66,7 @@ Be selective. Only capture knowledge useful to someone working on this project l
 
 /**
  * Spawn a detached pi distill process that survives parent exit.
+ * Uses `trap '' HUP` so both the shell and pi survive SIGHUP (tmux pane close).
  * Returns immediately — the child runs independently.
  */
 function spawnDetachedDistill(
@@ -117,6 +129,26 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    // Catch SIGHUP (tmux pane close / cmd+W in iTerm) — pi gets killed
+    // before session_shutdown can run, so we spawn the detached distill here.
+    // Store latest ctx so the handler always uses the most recent session.
+    latestCtx = ctx;
+    latestConfig = config;
+    if (!sighupRegistered) {
+      sighupRegistered = true;
+      process.on('SIGHUP', () => {
+        if (process.env.NAPKIN_DISTILL_NO_RECURSE) return;
+        if (sighupSpawned) return;
+        sighupSpawned = true;
+        const ctx = latestCtx!;
+        const sessionFile = ctx.sessionManager.getSessionFile?.();
+        if (!sessionFile || !fs.existsSync(sessionFile)) return;
+        const currentSize = fs.statSync(sessionFile).size;
+        if (currentSize === 0 || currentSize === lastSessionSize) return;
+        spawnDetachedDistill(sessionFile, ctx.cwd, latestConfig!);
+      });
+    }
+
     lastDistillTimestamp = Date.now();
     const intervalMs = config.intervalMinutes * 60 * 1000;
 
@@ -156,7 +188,6 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_shutdown", async (_event, ctx) => {
     // Prevent infinite recursion: detached distill processes must not spawn more distills
     if (process.env.NAPKIN_DISTILL_NO_RECURSE) return;
-
 
     if (countdownHandle) {
       clearInterval(countdownHandle);

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -5,9 +5,18 @@ import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
-// Process-level guards for SIGHUP handler
-let sighupRegistered = false;
-let sighupSpawned = false;
+const DEBUG = process.env.NAPKIN_DISTILL_DEBUG !== "0";
+const LOG_FILE = "/tmp/napkin-distill.log";
+function dbg(msg: string) {
+  if (!DEBUG) return;
+  fs.appendFileSync(LOG_FILE, `[${new Date().toISOString()}] ${msg}\n`);
+}
+
+dbg(`EXTENSION LOADED pid=${process.pid}`);
+
+// Process-level guards for SIGHUP/SIGTERM handler
+let signalHandlerRegistered = false;
+let signalSpawned = false;
 let latestCtx: any = null;
 let latestConfig: DistillConfig | null = null;
 
@@ -66,7 +75,6 @@ Be selective. Only capture knowledge useful to someone working on this project l
 
 /**
  * Spawn a detached pi distill process that survives parent exit.
- * Uses `trap '' HUP` so both the shell and pi survive SIGHUP (tmux pane close).
  * Returns immediately — the child runs independently.
  */
 function spawnDetachedDistill(
@@ -93,7 +101,7 @@ function spawnDetachedDistill(
     `${config.model.provider}/${config.model.id}`,
     DISTILL_PROMPT,
   ];
-  const shellCmd = `trap '' HUP; pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")} >/dev/null 2>&1; rm -rf '${tmpSessionDir}'`;
+  const shellCmd = `trap '' HUP; ${DEBUG ? `echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] START pid=$$ tmpdir=${tmpSessionDir}" >> ${LOG_FILE};` : ""} pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")} >/dev/null 2>&1; ${DEBUG ? `echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] DONE pid=$$ exit=$?" >> ${LOG_FILE};` : ""} rm -rf '${tmpSessionDir}'`;
 
   const proc = spawn("sh", ["-c", shellCmd], {
     cwd,
@@ -129,24 +137,29 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    // Catch SIGHUP (tmux pane close / cmd+W in iTerm) — pi gets killed
-    // before session_shutdown can run, so we spawn the detached distill here.
-    // Store latest ctx so the handler always uses the most recent session.
+    // Catch SIGHUP/SIGTERM (tmux pane close, kill <pid>) — pi does not
+    // handle these, so session_shutdown never fires. Spawn detached distill here.
     latestCtx = ctx;
     latestConfig = config;
-    if (!sighupRegistered) {
-      sighupRegistered = true;
-      process.on('SIGHUP', () => {
-        if (process.env.NAPKIN_DISTILL_NO_RECURSE) return;
-        if (sighupSpawned) return;
-        sighupSpawned = true;
+    if (!signalHandlerRegistered) {
+      signalHandlerRegistered = true;
+      const handleSignal = (sig: string) => {
+        if (process.env.NAPKIN_DISTILL_NO_RECURSE) { dbg(`${sig}: skip: NO_RECURSE`); return; }
+        if (signalSpawned) { dbg(`${sig}: skip: already spawned`); return; }
+        signalSpawned = true;
+        dbg(`${sig}: caught pid=${process.pid}`);
         const ctx = latestCtx!;
         const sessionFile = ctx.sessionManager.getSessionFile?.();
+        dbg(`${sig}: sessionFile=${sessionFile} exists=${sessionFile ? fs.existsSync(sessionFile) : 'N/A'}`);
         if (!sessionFile || !fs.existsSync(sessionFile)) return;
         const currentSize = fs.statSync(sessionFile).size;
+        dbg(`${sig}: currentSize=${currentSize} lastSessionSize=${lastSessionSize}`);
         if (currentSize === 0 || currentSize === lastSessionSize) return;
         spawnDetachedDistill(sessionFile, ctx.cwd, latestConfig!);
-      });
+        dbg(`${sig}: spawned detached distill`);
+      };
+      process.on('SIGHUP', () => handleSignal('SIGHUP'));
+      process.on('SIGTERM', () => handleSignal('SIGTERM'));
     }
 
     lastDistillTimestamp = Date.now();
@@ -186,8 +199,9 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
+    dbg(`SHUTDOWN: entered cwd=${ctx.cwd}`);
     // Prevent infinite recursion: detached distill processes must not spawn more distills
-    if (process.env.NAPKIN_DISTILL_NO_RECURSE) return;
+    if (process.env.NAPKIN_DISTILL_NO_RECURSE) { dbg('SHUTDOWN: skip: NO_RECURSE'); return; }
 
     if (countdownHandle) {
       clearInterval(countdownHandle);
@@ -202,6 +216,7 @@ export default function (pi: ExtensionAPI) {
     // The parent's finally block may never run after shutdown, so we
     // re-spawn as a detached shell wrapper that cleans up the temp dir.
     if (activeProcess && activeTmpDir) {
+      dbg('SHUTDOWN: path: activeProcess+activeTmpDir — re-spawning detached');
       const tmpDir = activeTmpDir;
       try {
         activeProcess.kill();
@@ -213,32 +228,37 @@ export default function (pi: ExtensionAPI) {
 
       // Re-spawn as detached so it survives parent exit with cleanup
       const vaultPath = findVaultPath(ctx.cwd);
-      if (!vaultPath) return;
+      if (!vaultPath) { dbg('SHUTDOWN: skip: no vault'); return; }
       const config = loadDistillConfig(vaultPath);
       const sessionFile = ctx.sessionManager.getSessionFile?.();
-      if (!sessionFile) return;
+      if (!sessionFile) { dbg('SHUTDOWN: skip: no session file'); return; }
       spawnDetachedDistill(sessionFile, ctx.cwd, config);
       fs.rmSync(tmpDir, { recursive: true, force: true });
+      dbg('SHUTDOWN: re-spawned detached');
       return;
     }
 
     // No distill running — check if session has new content worth distilling
     const vaultPath = findVaultPath(ctx.cwd);
-    if (!vaultPath) return;
+    dbg(`SHUTDOWN: vaultPath=${vaultPath} cwd=${ctx.cwd}`);
+    if (!vaultPath) { dbg('SHUTDOWN: skip: no vault'); return; }
 
     const config = loadDistillConfig(vaultPath);
-    if (!config.enabled) return;
+    if (!config.enabled) { dbg('SHUTDOWN: skip: not enabled'); return; }
 
     const sessionFile = ctx.sessionManager.getSessionFile?.();
-    if (!sessionFile) return;
+    dbg(`SHUTDOWN: sessionFile=${sessionFile} exists=${sessionFile ? fs.existsSync(sessionFile) : 'N/A'}`);
+    if (!sessionFile) { dbg('SHUTDOWN: skip: no session file'); return; }
 
     const currentSize = fs.existsSync(sessionFile)
       ? fs.statSync(sessionFile).size
       : 0;
-    if (currentSize === 0 || currentSize === lastSessionSize) return;
+    dbg(`SHUTDOWN: currentSize=${currentSize} lastSessionSize=${lastSessionSize}`);
+    if (currentSize === 0 || currentSize === lastSessionSize) { dbg('SHUTDOWN: skip: no change'); return; }
 
     // Spawn a detached distill that outlives this process
     spawnDetachedDistill(sessionFile, ctx.cwd, config);
+    dbg('SHUTDOWN: spawned detached');
   });
 
   async function runDistill(ctx: {

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -81,7 +81,7 @@ function spawnDetachedDistill(
     `${config.model.provider}/${config.model.id}`,
     DISTILL_PROMPT,
   ];
-  const shellCmd = `nohup pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")} >/dev/null 2>&1; rm -rf '${tmpSessionDir}'`;
+  const shellCmd = `trap '' HUP; pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")} >/dev/null 2>&1; rm -rf '${tmpSessionDir}'`;
 
   const proc = spawn("sh", ["-c", shellCmd], {
     cwd,

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -87,6 +87,7 @@ function spawnDetachedDistill(
     cwd,
     detached: true,
     stdio: "ignore",
+    env: { ...process.env, NAPKIN_DISTILL_NO_RECURSE: "1" },
   });
   proc.unref();
 }
@@ -153,6 +154,9 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
+    // Prevent infinite recursion: detached distill processes must not spawn more distills
+    if (process.env.NAPKIN_DISTILL_NO_RECURSE) return;
+
 
     if (countdownHandle) {
       clearInterval(countdownHandle);

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -53,6 +53,41 @@ const DISTILL_PROMPT = `Distill this conversation into the napkin vault.
 
 Be selective. Only capture knowledge useful to someone working on this project later. Skip meta-discussion, tool output, and chatter.`;
 
+/**
+ * Spawn a detached pi distill process that survives parent exit.
+ * Returns immediately — the child runs independently.
+ */
+function spawnDetachedDistill(
+  sessionFile: string,
+  cwd: string,
+  config: DistillConfig,
+): void {
+  const tmpSessionDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "napkin-distill-"),
+  );
+  const forkedSm = SessionManager.forkFrom(sessionFile, cwd, tmpSessionDir);
+  const forkedSessionFile = forkedSm.getSessionFile();
+  if (!forkedSessionFile) return;
+
+  // Wrap in a shell that cleans up the temp dir after pi exits
+  const piArgs = [
+    "--session",
+    forkedSessionFile,
+    "-p",
+    "--model",
+    `${config.model.provider}/${config.model.id}`,
+    DISTILL_PROMPT,
+  ];
+  const shellCmd = `pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")}; rm -rf '${tmpSessionDir}'`;
+
+  const proc = spawn("sh", ["-c", shellCmd], {
+    cwd,
+    detached: true,
+    stdio: "ignore",
+  });
+  proc.unref();
+}
+
 export default function (pi: ExtensionAPI) {
   let intervalHandle: ReturnType<typeof setInterval> | null = null;
   let countdownHandle: ReturnType<typeof setInterval> | null = null;
@@ -60,6 +95,7 @@ export default function (pi: ExtensionAPI) {
   let lastSessionSize = 0;
   let isRunning = false;
   let activeProcess: ReturnType<typeof spawn> | null = null;
+  let activeTmpDir: string | null = null;
 
   pi.on("session_start", async (_event, ctx) => {
     const vaultPath = findVaultPath(ctx.cwd);
@@ -113,7 +149,8 @@ export default function (pi: ExtensionAPI) {
     );
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", async (_event, ctx) => {
+
     if (countdownHandle) {
       clearInterval(countdownHandle);
       countdownHandle = null;
@@ -122,10 +159,36 @@ export default function (pi: ExtensionAPI) {
       clearInterval(intervalHandle);
       intervalHandle = null;
     }
+
+    // If a distill is already running, detach it instead of killing it
     if (activeProcess) {
-      activeProcess.kill();
+      try {
+        activeProcess.unref();
+      } catch {
+        // already dead — ignore
+      }
       activeProcess = null;
+      activeTmpDir = null; // skip cleanup in runDistill's finally block
+      return;
     }
+
+    // No distill running — check if session has new content worth distilling
+    const vaultPath = findVaultPath(ctx.cwd);
+    if (!vaultPath) return;
+
+    const config = loadDistillConfig(vaultPath);
+    if (!config.enabled) return;
+
+    const sessionFile = ctx.sessionManager.getSessionFile?.();
+    if (!sessionFile) return;
+
+    const currentSize = fs.existsSync(sessionFile)
+      ? fs.statSync(sessionFile).size
+      : 0;
+    if (currentSize === 0 || currentSize === lastSessionSize) return;
+
+    // Spawn a detached distill that outlives this process
+    spawnDetachedDistill(sessionFile, ctx.cwd, config);
   });
 
   async function runDistill(ctx: {
@@ -182,6 +245,7 @@ export default function (pi: ExtensionAPI) {
     const tmpSessionDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "napkin-distill-"),
     );
+    activeTmpDir = tmpSessionDir;
     let forkedSessionFile: string | null = null;
 
     try {
@@ -262,8 +326,11 @@ export default function (pi: ExtensionAPI) {
     } finally {
       if (timerHandle) clearInterval(timerHandle);
       isRunning = false;
-      // Clean up forked session
-      fs.rmSync(tmpSessionDir, { recursive: true, force: true });
+      // Clean up forked session — skip if shutdown detached the process
+      if (activeTmpDir === tmpSessionDir) {
+        fs.rmSync(tmpSessionDir, { recursive: true, force: true });
+        activeTmpDir = null;
+      }
     }
   }
 

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -67,7 +67,10 @@ function spawnDetachedDistill(
   );
   const forkedSm = SessionManager.forkFrom(sessionFile, cwd, tmpSessionDir);
   const forkedSessionFile = forkedSm.getSessionFile();
-  if (!forkedSessionFile) return;
+  if (!forkedSessionFile) {
+    fs.rmSync(tmpSessionDir, { recursive: true, force: true });
+    return;
+  }
 
   // Wrap in a shell that cleans up the temp dir after pi exits
   const piArgs = [
@@ -160,15 +163,27 @@ export default function (pi: ExtensionAPI) {
       intervalHandle = null;
     }
 
-    // If a distill is already running, detach it instead of killing it
-    if (activeProcess) {
+    // If a distill is already running, detach it instead of killing it.
+    // The parent's finally block may never run after shutdown, so we
+    // re-spawn as a detached shell wrapper that cleans up the temp dir.
+    if (activeProcess && activeTmpDir) {
+      const tmpDir = activeTmpDir;
       try {
-        activeProcess.unref();
+        activeProcess.kill();
       } catch {
         // already dead — ignore
       }
       activeProcess = null;
-      activeTmpDir = null; // skip cleanup in runDistill's finally block
+      activeTmpDir = null;
+
+      // Re-spawn as detached so it survives parent exit with cleanup
+      const vaultPath = findVaultPath(ctx.cwd);
+      if (!vaultPath) return;
+      const config = loadDistillConfig(vaultPath);
+      const sessionFile = ctx.sessionManager.getSessionFile?.();
+      if (!sessionFile) return;
+      spawnDetachedDistill(sessionFile, ctx.cwd, config);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
       return;
     }
 

--- a/.pi/extensions/distill/index.ts
+++ b/.pi/extensions/distill/index.ts
@@ -81,7 +81,7 @@ function spawnDetachedDistill(
     `${config.model.provider}/${config.model.id}`,
     DISTILL_PROMPT,
   ];
-  const shellCmd = `pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")}; rm -rf '${tmpSessionDir}'`;
+  const shellCmd = `nohup pi ${piArgs.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")} >/dev/null 2>&1; rm -rf '${tmpSessionDir}'`;
 
   const proc = spawn("sh", ["-c", shellCmd], {
     cwd,


### PR DESCRIPTION
## Problem

When pi exits (Ctrl+C, cmd+W, or tmux pane close), the distill extension kills any running distill subprocess and does not trigger a final one. If the interval timer has not fired yet, knowledge from the session is lost unless the user manually runs `/distill` and waits for it to complete before closing.

Additionally, `findVaultPath` only walks up from cwd, so sessions with cwd outside `$HOME` (e.g. `/workplace/...`) never find the vault at `~/.napkin`.

## Solution

Spawn a detached `pi -p` distill process on shutdown that survives parent exit. Three shutdown paths are covered:

1. **Graceful exit (Ctrl+C)**: `session_shutdown` fires, forks the session to a temp dir, spawns a detached `sh -c "trap '' HUP; pi ...; rm -rf tmpdir"` process with `detached: true` + `unref()`.

2. **Tmux pane close / cmd+W (SIGHUP)**: pi gets killed before `session_shutdown` can run. A `process.on('SIGHUP')` handler registered in `session_start` spawns the detached distill directly. Guarded with `sighupRegistered` + `sighupSpawned` flags to ensure exactly one distill per signal.

3. **Running distill at shutdown**: if a distill is already in progress, it is detached (not killed) so it completes independently.

### Additional fixes

- **Fork bomb prevention**: detached distill processes set `NAPKIN_DISTILL_NO_RECURSE=1` env var. Both `session_shutdown` and the SIGHUP handler check this and bail out early, preventing infinite recursion.

- **SIGHUP survival**: `trap '' HUP` in the shell wrapper ignores SIGHUP for both the shell and pi (inherited signal disposition), so the process survives tmux pane close and the `rm -rf` cleanup runs after pi exits.

- **`$HOME` vault fallback**: `findVaultPath` now checks `os.homedir()/.napkin` as a fallback after the directory walk, so sessions with cwd outside `$HOME` can still find the vault.

## Testing

- **Ctrl+C (graceful)**: session_shutdown fires, session file exists (828KB+), distill spawns and completes, vault files written, temp dir cleaned up ✅
- **cmd+W (iTerm tmux control mode)**: SIGHUP handler fires, session file exists (1MB), exactly 1 distill spawns, vault files written, temp dir cleaned up ✅
- **Fork bomb**: confirmed NAPKIN_DISTILL_NO_RECURSE prevents recursive spawning — was previously creating 29+ concurrent processes in a chain reaction ✅
- **Vault fallback**: sessions in `/workplace/...` now find vault at `~/.napkin` ✅
- **Interval distill**: existing timer-based distill continues to work unchanged ✅