### PR TITLE
feat: add global vault config fallback via ~/.config/napkin/config.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@biomejs/biome": "^2.3.14",
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^25.6.0",
         "typescript": "^5.8.0"
       },
       "optionalDependencies": {
@@ -219,7 +220,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "dev": true
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/bun-types": {
       "version": "1.3.12",
@@ -411,6 +419,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/src/utils/vault.test.ts
+++ b/src/utils/vault.test.ts
@@ -30,6 +30,8 @@ describe("findVault", () => {
 
   test("auto-creates vault when none found", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-auto-"));
+    const origXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = tmpDir; // isolate from global config
     try {
       const result = findVault(tmpDir);
       expect(result.contentPath).toBe(tmpDir);
@@ -41,7 +43,61 @@ describe("findVault", () => {
       expect(fs.existsSync(path.join(tmpDir, "NAPKIN.md"))).toBe(true);
       expect(fs.existsSync(path.join(tmpDir, ".obsidian"))).toBe(true);
     } finally {
+      if (origXdg !== undefined) process.env.XDG_CONFIG_HOME = origXdg;
+      else delete process.env.XDG_CONFIG_HOME;
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to global vault from XDG config", () => {
+    const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-global-vault-"));
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-global-config-"));
+    const napkinConfigDir = path.join(configDir, "napkin");
+    fs.mkdirSync(napkinConfigDir, { recursive: true });
+    // Create a vault in globalDir
+    const napkinDir = path.join(globalDir, ".napkin");
+    fs.mkdirSync(path.join(napkinDir, ".obsidian"), { recursive: true });
+    fs.writeFileSync(
+      path.join(napkinDir, "config.json"),
+      JSON.stringify({ vault: { root: "..", obsidian: "../.obsidian" } }),
+    );
+    // Write global config pointing to globalDir
+    fs.writeFileSync(
+      path.join(napkinConfigDir, "config.json"),
+      JSON.stringify({ vault: globalDir }),
+    );
+    const origXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configDir;
+    try {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-fallback-"));
+      const result = findVault(tmpDir);
+      expect(result.configPath).toBe(path.join(globalDir, ".napkin"));
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } finally {
+      if (origXdg !== undefined) process.env.XDG_CONFIG_HOME = origXdg;
+      else delete process.env.XDG_CONFIG_HOME;
+      fs.rmSync(globalDir, { recursive: true, force: true });
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores invalid global config", () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-bad-config-"));
+    const napkinConfigDir = path.join(configDir, "napkin");
+    fs.mkdirSync(napkinConfigDir, { recursive: true });
+    fs.writeFileSync(path.join(napkinConfigDir, "config.json"), "not json");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "napkin-no-vault-"));
+    const origXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configDir;
+    try {
+      const result = findVault(tmpDir);
+      // Should fall through to createBareVault
+      expect(result.contentPath).toBe(tmpDir);
+    } finally {
+      if (origXdg !== undefined) process.env.XDG_CONFIG_HOME = origXdg;
+      else delete process.env.XDG_CONFIG_HOME;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(configDir, { recursive: true, force: true });
     }
   });
 

--- a/src/utils/vault.ts
+++ b/src/utils/vault.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 export interface VaultInfo {
@@ -14,7 +15,8 @@ export interface VaultInfo {
 
 /**
  * Walk up from startDir looking for .napkin/ (or .obsidian/.napkin/ for nested layout).
- * Resolves the vault layout from config to determine content, config, and obsidian paths.
+ * Falls back to the global vault configured in $XDG_CONFIG_HOME/napkin/config.json.
+ * Creates a bare vault at the starting directory as a last resort.
  */
 export function findVault(startDir?: string): VaultInfo {
   let dir = path.resolve(startDir || process.cwd());
@@ -40,11 +42,49 @@ export function findVault(startDir?: string): VaultInfo {
 
     const parent = path.dirname(dir);
     if (parent === dir || dir === root) {
-      // No vault found — create a bare one at the starting directory
-      return createBareVault(startingDir);
+      break;
     }
     dir = parent;
   }
+
+  // Fall back to global vault from user config
+  const globalVault = getGlobalConfigVault();
+  if (globalVault) {
+    return resolveVaultLayout(globalVault, path.dirname(globalVault));
+  }
+
+  // No vault found — create a bare one at the starting directory
+  return createBareVault(startingDir);
+}
+
+/**
+ * Check for a global vault configured in the user's config directory.
+ * Reads the `vault` field from $XDG_CONFIG_HOME/napkin/config.json
+ * (defaults to ~/.config/napkin/config.json).
+ *
+ * Returns the .napkin/ path if a valid vault is configured, null otherwise.
+ */
+function getGlobalConfigVault(): string | null {
+  const configHome =
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  const configPath = path.join(configHome, "napkin", "config.json");
+  if (!fs.existsSync(configPath)) return null;
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    if (!raw.vault) return null;
+
+    const vaultPath: string = raw.vault.startsWith("~")
+      ? path.join(os.homedir(), raw.vault.slice(1))
+      : path.resolve(raw.vault);
+
+    const napkinDir = path.join(vaultPath, ".napkin");
+    if (fs.existsSync(napkinDir)) return napkinDir;
+  } catch {
+    // invalid config
+  }
+
+  return null;
 }
 
 /**

--- a/src/utils/vault.ts
+++ b/src/utils/vault.ts
@@ -74,9 +74,10 @@ function getGlobalConfigVault(): string | null {
     const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     if (!raw.vault) return null;
 
-    const vaultPath: string = raw.vault.startsWith("~")
-      ? path.join(os.homedir(), raw.vault.slice(1))
-      : path.resolve(raw.vault);
+    const vaultPath =
+      raw.vault === "~" || raw.vault.startsWith("~/")
+        ? path.join(os.homedir(), raw.vault.slice(1))
+        : path.resolve(path.dirname(configPath), raw.vault);
 
     const napkinDir = path.join(vaultPath, ".napkin");
     if (fs.existsSync(napkinDir)) return napkinDir;


### PR DESCRIPTION
## Summary

Add XDG-compliant global config fallback to `findVault()` resolution order. When no `.napkin/` directory is found walking up from cwd, the CLI now checks $XDG_CONFIG_HOME/napkin/config.json (defaults to \~/.config/napkin/config.json) for a configured vault path before creating a bare vault.

### Motivation

Agent frameworks like [pi-napkin](https://github.com/Michaelliv/pi-napkin) need a way to configure a default vault for projects that don't have a local `.napkin/` directory. Currently, pi-napkin has its own [vault-resolve.ts](https://github.com/Michaelliv/pi-napkin/blob/main/extensions/vault-resolve.ts) that duplicates napkin's walk-up logic and adds a `\~/.pi/agent/napkin.json` fallback. Moving this into napkin-ai eliminates the duplication and gives all agent frameworks a consistent, standard way to configure a default vault.

### Resolution order

1. Walk up from cwd for `.napkin/` (or `.obsidian/.napkin/`)
2. Read `vault` field from $XDG_CONFIG_HOME/napkin/config.json
3. Create bare vault at cwd (last resort)

### Config format

```json
// ~/.config/napkin/config.json
{
  "vault": "~/path/to/vault"
}
```

### Changes

- **src/utils/vault.ts**: Added `getGlobalConfigVault()` between walk-up loop and `createBareVault()`
  - Respects `XDG_CONFIG_HOME` env var (defaults to `~/.config`)
  - Tilde expansion: only `~` and `~/...` (not `\~user`)
  - Relative paths resolve relative to config directory (not cwd)
- **src/utils/vault.test.ts**: Added tests for global config fallback, test isolation via XDG_CONFIG_HOME override

### Companion PR

- [pi-napkin#3](https://github.com/Michaelliv/pi-napkin/pull/3) — removes duplicated vault-resolve.ts, uses napkin-ai's native resolution