### PR TITLE
chore: add prepare script for git dependency builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "dev": "bun run src/main.ts",
     "build:bun": "bun build --compile src/main.ts --outfile napkin",


### PR DESCRIPTION
## Summary

Add `prepare` script to package.json so that `npm install` from a git source builds the `dist/` directory automatically.

### Problem

When napkin-ai is installed as a git dependency (e.g. `"napkin-ai": "github:cad0p/napkin"`), npm runs the `prepare` lifecycle script after install. Without it, the `dist/` directory is missing and importing napkin-ai fails with:

```
Cannot find module '.../napkin-ai/dist/index.js'
```

The existing `prepublishOnly` script only runs on `npm publish`, not on git-based installs.

### Fix

```diff
"scripts": {
  "build": "tsc",
+ "prepare": "npm run build",
  "prepublishOnly": "npm run build",
```

This ensures `tsc` runs automatically after install from git, making git dependencies work out of the box. For npm installs, `dist/` is already published so `prepare` is a no-op (files already exist).