### PR TITLE
Add `napkin update` self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ napkin search "authentication"
 # Read a file
 napkin read "Architecture"
 
+# Update the CLI
+napkin update
+
 # Write
 napkin create "Decision" --template Decision
 napkin append "Decision" "We chose Postgres."
@@ -164,6 +167,7 @@ napkin read "Note" -q           # Raw markdown, nothing else
 ```bash
 napkin vault                          # Vault info
 napkin overview                       # Vault map with keywords
+napkin update                         # Update the napkin CLI
 napkin read <file>                    # Read file contents
 napkin create "Note" $'# Hello\nFirst note.'   # Create with content
 napkin append "Note" $'\n## Update\nNew info.'   # Append to file

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { update } from "./update.js";
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const originalLog = console.log;
+const originalError = console.error;
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+});
+
+describe("update command", () => {
+  test("runs npm install globally for the latest napkin package", async () => {
+    // Arrange
+    const calls: Array<{ command: string; args: string[] }> = [];
+    console.log = () => {};
+
+    // Act
+    await update({}, async (command, args) => {
+      calls.push({ command, args });
+      return 0;
+    });
+
+    // Assert
+    expect(calls).toEqual([
+      { command: npmCommand, args: ["install", "-g", "napkin-ai@latest"] },
+    ]);
+  });
+});

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,30 +1,128 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { update } from "./update.js";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EXIT_ERROR } from "../utils/exit-codes.js";
+import { type CommandRunner, update } from "./update.js";
 
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const originalLog = console.log;
 const originalError = console.error;
+let logs: string[];
+let errors: string[];
+
+beforeEach(() => {
+  logs = [];
+  errors = [];
+  console.log = (...args) => logs.push(args.join(" "));
+  console.error = (...args) => errors.push(args.join(" "));
+});
 
 afterEach(() => {
   console.log = originalLog;
   console.error = originalError;
 });
 
+async function captureExit(fn: () => Promise<void>): Promise<number> {
+  const originalExit = process.exit;
+  let exitCode = -1;
+  (process as unknown as Record<string, unknown>).exit = (code: number) => {
+    exitCode = code;
+    throw new Error("exit");
+  };
+
+  try {
+    await fn();
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "exit") throw error;
+  } finally {
+    (process as unknown as Record<string, unknown>).exit = originalExit;
+  }
+
+  return exitCode;
+}
+
 describe("update command", () => {
   test("runs npm install globally for the latest napkin package", async () => {
-    // Arrange
-    const calls: Array<{ command: string; args: string[] }> = [];
-    console.log = () => {};
+    const calls: Array<{
+      command: string;
+      args: string[];
+      options: { silent: boolean };
+    }> = [];
 
-    // Act
-    await update({}, async (command, args) => {
-      calls.push({ command, args });
+    await update({}, async (command, args, options) => {
+      calls.push({ command, args, options });
       return 0;
     });
 
-    // Assert
     expect(calls).toEqual([
-      { command: npmCommand, args: ["install", "-g", "napkin-ai@latest"] },
+      {
+        command: npmCommand,
+        args: ["install", "-g", "napkin-ai@latest"],
+        options: { silent: false },
+      },
     ]);
+    expect(logs.join("\n")).toContain("Updated napkin-ai@latest");
+  });
+
+  test("returns structured JSON and silences npm output", async () => {
+    let silent = false;
+
+    await update({ json: true }, async (_command, _args, options) => {
+      silent = options.silent;
+      return 0;
+    });
+
+    expect(silent).toBe(true);
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0] ?? "")).toEqual({
+      updated: true,
+      target: "napkin-ai@latest",
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("suppresses command and npm output in quiet mode", async () => {
+    let silent = false;
+
+    await update({ quiet: true }, async (_command, _args, options) => {
+      silent = options.silent;
+      return 0;
+    });
+
+    expect(silent).toBe(true);
+    expect(logs).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test("reports a non-zero npm exit status", async () => {
+    const exitCode = await captureExit(() => update({}, async () => 7));
+
+    expect(exitCode).toBe(EXIT_ERROR);
+    expect(errors.join("\n")).toContain("exited with status 7");
+  });
+
+  test("returns structured JSON for a failed update", async () => {
+    const exitCode = await captureExit(() =>
+      update({ json: true }, async () => 2),
+    );
+
+    expect(exitCode).toBe(EXIT_ERROR);
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0] ?? "")).toEqual({
+      updated: false,
+      target: "napkin-ai@latest",
+      error: `${npmCommand} install -g napkin-ai@latest exited with status 2`,
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("adds context when npm cannot be started", async () => {
+    const runner: CommandRunner = async () => {
+      throw new Error("not found");
+    };
+    const exitCode = await captureExit(() => update({}, runner));
+
+    expect(exitCode).toBe(EXIT_ERROR);
+    expect(errors.join("\n")).toContain(
+      `Update failed: Could not run ${npmCommand}: not found`,
+    );
   });
 });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,36 @@
+import { spawn } from "node:child_process";
+import { EXIT_ERROR } from "../utils/exit-codes.js";
+import { error, info, type OutputOptions, success } from "../utils/output.js";
+
+const target = "napkin-ai@latest";
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmArgs = ["install", "-g", target];
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+) => Promise<number>;
+
+export async function update(
+  opts: OutputOptions,
+  runner: CommandRunner = runCommand,
+): Promise<void> {
+  if (!opts.quiet)
+    info(`Updating napkin with ${npmCommand} ${npmArgs.join(" ")}`);
+
+  const status = await runner(npmCommand, npmArgs);
+  if (status !== 0) {
+    error(`Update failed: ${npmCommand} ${npmArgs.join(" ")}`);
+    process.exit(EXIT_ERROR);
+  }
+
+  if (!opts.quiet) success(`Updated ${target}`);
+}
+
+function runCommand(command: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("close", (status) => resolve(status ?? 1));
+  });
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,36 +1,76 @@
 import { spawn } from "node:child_process";
 import { EXIT_ERROR } from "../utils/exit-codes.js";
-import { error, info, type OutputOptions, success } from "../utils/output.js";
+import {
+  error,
+  info,
+  type OutputOptions,
+  output,
+  success,
+} from "../utils/output.js";
 
 const target = "napkin-ai@latest";
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const npmArgs = ["install", "-g", target];
 
+interface RunOptions {
+  silent: boolean;
+}
+
 export type CommandRunner = (
   command: string,
   args: string[],
+  options: RunOptions,
 ) => Promise<number>;
 
 export async function update(
   opts: OutputOptions,
   runner: CommandRunner = runCommand,
 ): Promise<void> {
-  if (!opts.quiet)
-    info(`Updating napkin with ${npmCommand} ${npmArgs.join(" ")}`);
+  const command = `${npmCommand} ${npmArgs.join(" ")}`;
 
-  const status = await runner(npmCommand, npmArgs);
-  if (status !== 0) {
-    error(`Update failed: ${npmCommand} ${npmArgs.join(" ")}`);
-    process.exit(EXIT_ERROR);
+  if (!opts.quiet && !opts.json) info(`Updating napkin with ${command}`);
+
+  let status: number;
+  try {
+    status = await runner(npmCommand, npmArgs, {
+      silent: Boolean(opts.quiet || opts.json),
+    });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    fail(opts, `Could not run ${npmCommand}: ${message}`);
   }
 
-  if (!opts.quiet) success(`Updated ${target}`);
+  if (status !== 0) fail(opts, `${command} exited with status ${status}`);
+
+  output(opts, {
+    json: () => ({ updated: true, target }),
+    quiet: () => {},
+    human: () => success(`Updated ${target}`),
+  });
 }
 
-function runCommand(command: string, args: string[]): Promise<number> {
+function fail(opts: OutputOptions, message: string): never {
+  if (opts.json) {
+    output(opts, {
+      json: () => ({ updated: false, target, error: message }),
+      human: () => {},
+    });
+  } else {
+    error(`Update failed: ${message}`);
+  }
+  process.exit(EXIT_ERROR);
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: RunOptions,
+): Promise<number> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: "inherit" });
-    child.on("error", reject);
-    child.on("close", (status) => resolve(status ?? 1));
+    const child = spawn(command, args, {
+      stdio: options.silent ? "ignore" : "inherit",
+    });
+    child.once("error", reject);
+    child.once("close", (status) => resolve(status ?? 1));
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,7 @@ import {
   templateRead,
   templates,
 } from "./commands/templates.js";
+import { update } from "./commands/update.js";
 import { vault } from "./commands/vault.js";
 import { wordcount } from "./commands/wordcount.js";
 
@@ -92,6 +93,7 @@ Examples:
   $ napkin overview                  See what's in the vault
   $ napkin search "auth"             Find content about auth
   $ napkin read "Architecture"       Read a specific file
+  $ napkin update                    Update the napkin CLI
 
 Workflow: init → overview → search → read
 
@@ -101,6 +103,7 @@ Getting started:
   vault                Show vault info (path, file count, size)
   config               Vault configuration (show, get, set)
   graph                Interactive vault graph visualization
+  update               Update the napkin CLI via npm
 
 Reading:
   read <file>          Read a file
@@ -180,6 +183,14 @@ program
   .action(async (_opts, cmd) => {
     const root = cmd.optsWithGlobals();
     await vault(root);
+  });
+
+program
+  .command("update")
+  .description("Update the napkin CLI")
+  .action(async (_opts, cmd) => {
+    const root = cmd.optsWithGlobals();
+    await update(root);
   });
 
 // ── Reading ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #17.

## Summary

- Add `napkin update` to run `npm install -g napkin-ai@latest` from the CLI.
- Document the new command in the README and main help text.

## Verification

- `bun test`
- `npm run build`
- `npm run check` (passes with existing warning-only lint findings)
