### PR TITLE
Noise-robust overview: structured-noise stripping + homogeneous-sibling collapse

### DIFF
--- a/src/commands/overview.test.ts
+++ b/src/commands/overview.test.ts
@@ -75,12 +75,16 @@ describe("overview", () => {
     const warnings: string[] = [];
     const captured: unknown[] = [];
     const origLog = console.log;
+    const origError = console.error;
 
     try {
-      console.log = (...args: unknown[]) => {
+      // Warnings go to stderr so they never corrupt --json output on stdout.
+      console.error = (...args: unknown[]) => {
         const msg = args.map(String).join(" ");
         if (msg.includes("⚠")) warnings.push(msg);
-        else captured.push(...args);
+      };
+      console.log = (...args: unknown[]) => {
+        captured.push(...args);
       };
       await overview({
         vault: vault.path,
@@ -90,6 +94,7 @@ describe("overview", () => {
       });
     } finally {
       console.log = origLog;
+      console.error = origError;
     }
 
     const result = JSON.parse(captured[0] as string) as {
@@ -175,6 +180,110 @@ Two merchants need migration plans.`,
     expect(decisionsFolder?.keywords).not.toContain("context");
     expect(decisionsFolder?.keywords).not.toContain("decision");
     expect(decisionsFolder?.keywords).not.toContain("consequences");
+
+    vault.cleanup();
+  });
+
+  test("strips structured noise from converted documents", async () => {
+    const vault = createTempVault({
+      "contracts/lease.md": `# Lease agreement
+DocuSign Envelope ID: AAAA1111-2222-4333-ADAB-BCF123456789
+<div align="center">&nbsp;</div>
+Tenant leases the third floor. Envelope ID: BBBB2222-3333-4444-EAEC-DEF987654321
+Sublease requires landlord approval and a bank guarantee.`,
+      "contracts/parking.md": `# Parking addendum
+DocuSign Envelope ID: CCCC3333-4444-4555-FADE-CAB456789012
+<div align="center">&nbsp;</div>
+Reserved parking slots on level B2. Guarantee covers parking fees.`,
+    });
+
+    const result = (await runOverviewJson(vault.path)) as {
+      overview: Array<{ path: string; keywords: string[] }>;
+    };
+    const folder = result.overview.find((f) => f.path === "contracts");
+    expect(folder).toBeDefined();
+    const tokens = folder?.keywords.flatMap((k) => k.split(" ")) ?? [];
+    // GUID shrapnel ("adeb", "f25", ...) and HTML residue never become keywords
+    for (const t of tokens) {
+      expect(t).not.toMatch(/^[a-f0-9]{3,8}$/);
+      expect(t).not.toBe("div");
+      expect(t).not.toBe("align");
+      expect(t).not.toBe("nbsp");
+    }
+    expect(tokens).toContain("guarantee");
+
+    vault.cleanup();
+  });
+
+  test("collapses numerous homogeneous sibling folders", async () => {
+    const files: Record<string, string> = {
+      "procedures/deploy.md":
+        "# Deploy checklist\nRun the smoke tests, then promote the build.",
+    };
+    // six near-identical converted-contract subfolders under imports/ —
+    // heavy shared boilerplate, rotated so no sentence is in every folder
+    const boilerplate = [
+      "Lease agreement between landlord and tenant with signature page attached.",
+      "Rent schedule and lease term apply as stated in the appendix.",
+      "Bank guarantee and insurance certificate are required before occupancy.",
+    ];
+    for (let i = 0; i < 6; i++) {
+      const shared = boilerplate.filter((_, j) => j !== i % 3).join("\n");
+      files[`imports/tenant-${i}/contract.md`] =
+        `# Converted document ${i}\n${shared}\nSuite ${100 + i} on floor ${i}.`;
+    }
+    const vault = createTempVault(files);
+
+    const result = (await runOverviewJson(vault.path)) as {
+      overview: Array<{
+        path: string;
+        notes: number;
+        collapsedFolders?: number;
+      }>;
+    };
+    const paths = result.overview.map((f) => f.path);
+    expect(paths).toContain("imports");
+    expect(paths).not.toContain("imports/tenant-0");
+    const imports = result.overview.find((f) => f.path === "imports");
+    expect(imports?.collapsedFolders).toBe(6);
+    expect(imports?.notes).toBe(6);
+    // curated folder untouched
+    expect(paths).toContain("procedures");
+
+    // top-level folders are never collapsed into the root
+    expect(paths).not.toContain("/");
+
+    // --no-collapse restores the full listing
+    const flat = (await runOverviewJson(vault.path, { collapse: false })) as {
+      overview: Array<{ path: string }>;
+    };
+    expect(flat.overview.map((f) => f.path)).toContain("imports/tenant-0");
+
+    vault.cleanup();
+  });
+
+  test("keeps heterogeneous sibling folders separate", async () => {
+    const files: Record<string, string> = {};
+    const topics = [
+      ["alpha", "Kubernetes ingress routing and pod autoscaling policies."],
+      ["beta", "Payroll tax withholding tables for hourly contractors."],
+      ["gamma", "Sourdough fermentation schedules and hydration ratios."],
+      ["delta", "Telescope collimation steps for reflector optics."],
+      ["epsilon", "Beehive winterization and varroa mite treatment."],
+      ["zeta", "Marathon training splits and lactate threshold pacing."],
+    ] as const;
+    for (const [name, body] of topics) {
+      files[`areas/${name}/note.md`] = `# ${name} notes\n${body}`;
+    }
+    const vault = createTempVault(files);
+
+    const result = (await runOverviewJson(vault.path)) as {
+      overview: Array<{ path: string }>;
+    };
+    const paths = result.overview.map((f) => f.path);
+    for (const [name] of topics) {
+      expect(paths).toContain(`areas/${name}`);
+    }
 
     vault.cleanup();
   });

--- a/src/commands/overview.ts
+++ b/src/commands/overview.ts
@@ -12,12 +12,14 @@ export async function overview(
     vault?: string;
     depth?: string;
     keywords?: string;
+    collapse?: boolean;
   },
 ) {
   const n = new Napkin(opts.vault || process.cwd());
   const result = n.overview({
     depth: opts.depth ? Number.parseInt(opts.depth, 10) : undefined,
     keywords: opts.keywords ? Number.parseInt(opts.keywords, 10) : undefined,
+    ...(opts.collapse === false ? { collapse: false } : {}),
   });
 
   for (const w of result.warnings ?? []) {
@@ -41,7 +43,10 @@ export async function overview(
         return;
       }
       for (const f of result.overview) {
-        console.log(bold(f.path === "/" ? "./" : `${f.path}/`));
+        const collapsedNote = f.collapsedFolders
+          ? dim(` (+${f.collapsedFolders} similar subfolders)`)
+          : "";
+        console.log(bold(f.path === "/" ? "./" : `${f.path}/`) + collapsedNote);
         if (f.keywords.length > 0) {
           console.log(`  ${dim("keywords:")} ${f.keywords.join(", ")}`);
         }

--- a/src/core/overview.ts
+++ b/src/core/overview.ts
@@ -10,6 +10,8 @@ export interface OverviewFolder {
   notes: number;
   keywords: string[];
   tags: string[];
+  /** Number of subfolders rolled up into this row (homogeneous-sibling collapse). */
+  collapsedFolders?: number;
 }
 
 export interface VaultOverview {
@@ -23,6 +25,24 @@ const INLINE_CODE_RE = /`[^`]+`/g;
 const URL_RE = /https?:\/\/[^\s)>\]]+/g;
 const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 const HEX_HASH_RE = /\b[a-f0-9]{8,}\b/g;
+// Structured noise from imported/converted documents (OCR'd PDFs, DocuSign
+// exports, HTML conversions). Stripped before tokenization so ID shrapnel
+// ("DAB4-BCF3-..." → "dab", "bcf") never reaches keyword scoring.
+const DASHED_HEX_RE = /\b[0-9a-f]{2,}(?:-[0-9a-f]{2,})+\b/gi;
+const DIGIT_BLOB_RE = /\b(?=[0-9a-z]*\d)(?=[0-9a-z]*[a-z])[0-9a-z]{6,}\b/gi;
+const HTML_TAG_RE = /<\/?[a-z][^>]*>/gi;
+const HTML_ENTITY_RE = /&[a-z]+;|&#\d+;/gi;
+const HEXLETTER_RUN_RE = /\b[a-f]{7,}\b/gi;
+
+// Homogeneous-sibling collapse: parents with at least this many children
+// whose term distributions are at least this similar (mean pairwise cosine
+// over top terms) are rendered as a single aggregate row. Tuned against a
+// corpus of real-world agent vaults — imported document dumps sit at ~0.15–0.25
+// similarity, curated folder structures below ~0.05.
+const COLLAPSE_MIN_CHILDREN = 5;
+const COLLAPSE_SIMILARITY = 0.15;
+const COLLAPSE_COSINE_TOP_TERMS = 60;
+const COLLAPSE_PAIRWISE_CAP = 20;
 const TOKEN_RE = /[a-z]{3,}/g;
 const FRONTMATTER_RE = /^---[\s\S]*?---\n?/;
 const ATX_HEADING_LINE_RE = /^#{1,6}\s+.+$/gm;
@@ -177,6 +197,12 @@ interface HeadingSignals {
 
 interface FolderData {
   tf: Map<string, number>;
+  /**
+   * Term frequencies from note content (bodies and heading lines, unweighted;
+   * no filename or title terms). Used for sibling-collapse similarity so
+   * shared naming conventions cannot fake content homogeneity.
+   */
+  bodyTF: Map<string, number>;
   headingLineCount: Map<string, number>;
   hasNonHeading: Set<string>;
   tags: Set<string>;
@@ -189,6 +215,11 @@ function stripNoise(text: string): string {
     .replace(INLINE_CODE_RE, "")
     .replace(URL_RE, "")
     .replace(EMAIL_RE, "")
+    .replace(HTML_TAG_RE, " ")
+    .replace(HTML_ENTITY_RE, " ")
+    .replace(DASHED_HEX_RE, " ")
+    .replace(DIGIT_BLOB_RE, " ")
+    .replace(HEXLETTER_RUN_RE, " ")
     .replace(HEX_HASH_RE, "");
 }
 
@@ -368,6 +399,116 @@ function extractKeywordsTFIDF(
   return selected;
 }
 
+/** Cosine similarity over the top-N terms of two TF maps. */
+function tfCosine(a: Map<string, number>, b: Map<string, number>): number {
+  const top = (m: Map<string, number>) =>
+    new Map(
+      [...m.entries()]
+        .sort((x, y) => y[1] - x[1])
+        .slice(0, COLLAPSE_COSINE_TOP_TERMS),
+    );
+  const ta = top(a);
+  const tb = top(b);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (const [, v] of ta) na += v * v;
+  for (const [, v] of tb) nb += v * v;
+  for (const [k, v] of ta) {
+    const w = tb.get(k);
+    if (w) dot += v * w;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function mergeFolderData(items: FolderData[]): FolderData {
+  const tf = new Map<string, number>();
+  const bodyTF = new Map<string, number>();
+  const headingLineCount = new Map<string, number>();
+  const hasNonHeading = new Set<string>();
+  const tags = new Set<string>();
+  let noteCount = 0;
+  for (const d of items) {
+    for (const [k, v] of d.tf) tf.set(k, (tf.get(k) || 0) + v);
+    for (const [k, v] of d.bodyTF) bodyTF.set(k, (bodyTF.get(k) || 0) + v);
+    for (const [k, v] of d.headingLineCount) {
+      headingLineCount.set(k, (headingLineCount.get(k) || 0) + v);
+    }
+    for (const k of d.hasNonHeading) hasNonHeading.add(k);
+    for (const t of d.tags) tags.add(t);
+    noteCount += d.noteCount;
+  }
+  return { tf, bodyTF, headingLineCount, hasNonHeading, tags, noteCount };
+}
+
+/**
+ * Collapse numerous, lexically homogeneous sibling folders into their parent
+ * so repetitive subtrees (imported document dumps, per-entity folder fans)
+ * render as one aggregate row instead of dominating the overview. The vault
+ * root is never a collapse target: top-level folders are the taxonomy.
+ */
+function collapseHomogeneousSiblings(folderData: Map<string, FolderData>): {
+  data: Map<string, FolderData>;
+  collapsed: Map<string, number>;
+} {
+  const byParent = new Map<string, string[]>();
+  for (const folder of folderData.keys()) {
+    if (folder === "/") continue;
+    const idx = folder.lastIndexOf("/");
+    const parent = idx === -1 ? "/" : folder.slice(0, idx);
+    if (!byParent.has(parent)) byParent.set(parent, []);
+    byParent.get(parent)?.push(folder);
+  }
+
+  // Deepest parents first so collapses can cascade upward.
+  const parents = [...byParent.keys()].sort(
+    (a, b) => b.split("/").length - a.split("/").length,
+  );
+
+  const data = new Map(folderData);
+  const collapsed = new Map<string, number>();
+
+  for (const parent of parents) {
+    if (parent === "/") continue;
+    const children = (byParent.get(parent) || []).filter((c) => data.has(c));
+    if (children.length < COLLAPSE_MIN_CHILDREN) continue;
+
+    const cap = Math.min(children.length, COLLAPSE_PAIRWISE_CAP);
+    let sum = 0;
+    let pairs = 0;
+    for (let i = 0; i < cap; i++) {
+      for (let j = i + 1; j < cap; j++) {
+        const a = data.get(children[i]);
+        const b = data.get(children[j]);
+        if (!a || !b) continue;
+        sum += tfCosine(a.bodyTF, b.bodyTF);
+        pairs++;
+      }
+    }
+    if (pairs === 0 || sum / pairs < COLLAPSE_SIMILARITY) continue;
+
+    const toMerge: FolderData[] = [];
+    let mergedFolderCount = 0;
+    for (const child of children) {
+      const d = data.get(child);
+      if (!d) continue;
+      toMerge.push(d);
+      mergedFolderCount += 1 + (collapsed.get(child) || 0);
+      data.delete(child);
+      collapsed.delete(child);
+    }
+    const existing = data.get(parent);
+    const merged = existing
+      ? mergeFolderData([existing, ...toMerge])
+      : mergeFolderData(toMerge);
+    data.set(parent, merged);
+    collapsed.set(parent, (collapsed.get(parent) || 0) + mergedFolderCount);
+  }
+
+  return { data, collapsed };
+}
+
 function groupFilesByFolder(
   files: string[],
   templatesFolder: string,
@@ -394,6 +535,7 @@ function buildFolderData(
   const allTags = new Set<string>();
   const headings = new Set<string>();
   const weightedSources: WeightedText[] = [];
+  const bodyTF = new Map<string, number>();
 
   for (const file of folderFileList) {
     const content = fs.readFileSync(path.join(vaultPath, file), "utf-8");
@@ -411,8 +553,10 @@ function buildFolderData(
       for (const tag of properties.tags) allTags.add(String(tag));
     }
 
-    for (const heading of extractHeadings(content)) {
+    const fileHeadings = extractHeadings(content);
+    for (const heading of fileHeadings) {
       headings.add(heading.text.trim());
+      addWeightedTerms(bodyTF, terms(heading.text), 1);
     }
 
     weightedSources.push({ text: path.basename(file, ".md"), weight: 2 });
@@ -422,7 +566,9 @@ function buildFolderData(
     for (const value of frontmatterText(properties)) {
       weightedSources.push({ text: value, weight: 2 });
     }
-    weightedSources.push({ text: markdownBodyText(content), weight: 1 });
+    const body = markdownBodyText(content);
+    weightedSources.push({ text: body, weight: 1 });
+    addWeightedTerms(bodyTF, terms(body), 1);
   }
 
   const tf = buildTF(weightedSources);
@@ -435,6 +581,7 @@ function buildFolderData(
 
   return {
     tf,
+    bodyTF,
     headingLineCount: headingSignals.lineCount,
     hasNonHeading,
     tags: allTags,
@@ -447,11 +594,12 @@ function buildOverviewFolders(
   maxDepth: number,
   maxKeywords: number,
   templatesFolder: string,
+  collapse: boolean,
 ): { folders: OverviewFolder[]; warnings: string[] } {
   const files = listFiles(vaultPath, { ext: "md" });
   const warnings: string[] = [];
   const folderFiles = groupFilesByFolder(files, templatesFolder);
-  const folderData = new Map<string, FolderData>();
+  let folderData = new Map<string, FolderData>();
 
   for (const [folder, folderFileList] of folderFiles) {
     const depth = folder === "/" ? 0 : folder.split("/").length;
@@ -461,6 +609,13 @@ function buildOverviewFolders(
       folder,
       buildFolderData(vaultPath, folderFileList, warnings),
     );
+  }
+
+  let collapsedCounts = new Map<string, number>();
+  if (collapse) {
+    const result = collapseHomogeneousSiblings(folderData);
+    folderData = result.data;
+    collapsedCounts = result.collapsed;
   }
 
   const documentFrequency = new Map<string, number>();
@@ -489,6 +644,9 @@ function buildOverviewFolders(
         data.hasNonHeading,
       ),
       tags: [...data.tags].sort(),
+      ...(collapsedCounts.has(folder)
+        ? { collapsedFolders: collapsedCounts.get(folder) }
+        : {}),
     });
   }
 
@@ -498,17 +656,19 @@ function buildOverviewFolders(
 export function getOverview(
   contentPath: string,
   configPath: string,
-  opts?: { depth?: number; keywords?: number },
+  opts?: { depth?: number; keywords?: number; collapse?: boolean },
 ): VaultOverview {
   const config = loadConfig(configPath);
   const maxDepth = opts?.depth ?? config.overview.depth;
   const maxKeywords = opts?.keywords ?? config.overview.keywords;
+  const collapse = opts?.collapse ?? config.overview.collapse;
 
   const { folders, warnings } = buildOverviewFolders(
     contentPath,
     maxDepth,
     maxKeywords,
     config.templates.folder,
+    collapse,
   );
 
   const contextPath = path.join(contentPath, "NAPKIN.md");

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,6 +161,7 @@ program
   .description("Vault map with keywords (Level 1 progressive disclosure)")
   .option("--depth <n>", "Max folder depth")
   .option("--keywords <n>", "Max keywords per folder")
+  .option("--no-collapse", "Do not roll up homogeneous sibling folders")
   .action(async (opts, cmd) => {
     const root = { ...cmd.optsWithGlobals(), ...opts };
     await overview(root);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -115,7 +115,11 @@ export class Napkin {
     return getVaultMetadata(this.vault);
   }
 
-  overview(opts?: { depth?: number; keywords?: number }): VaultOverview {
+  overview(opts?: {
+    depth?: number;
+    keywords?: number;
+    collapse?: boolean;
+  }): VaultOverview {
     return getOverview(this.vault.contentPath, this.vault.configPath, opts);
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,6 +13,8 @@ export interface NapkinConfig {
   overview: {
     depth: number;
     keywords: number;
+    /** Roll up numerous, lexically homogeneous sibling folders into one row. */
+    collapse: boolean;
   };
   search: {
     limit: number;
@@ -34,6 +36,7 @@ export const DEFAULT_CONFIG: NapkinConfig = {
   overview: {
     depth: 3,
     keywords: 8,
+    collapse: true,
   },
   search: {
     limit: 30,

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -7,7 +7,7 @@ export interface OutputOptions {
 
 export const success = (msg: string) => console.log(chalk.green("✓"), msg);
 export const info = (msg: string) => console.log(chalk.blue("ℹ"), msg);
-export const warn = (msg: string) => console.log(chalk.yellow("⚠"), msg);
+export const warn = (msg: string) => console.error(chalk.yellow("⚠"), msg);
 export const error = (msg: string) => console.error(chalk.red("✗"), msg);
 export const errorWithHint = (msg: string, hint: string) => {
   console.error(chalk.red("✗"), msg);


### PR DESCRIPTION
## Problem

`napkin overview` exists to prime an agent with the vault's actual vocabulary so lexical search works. On vaults containing large imported/converted document subtrees (OCR'd PDFs, DocuSign exports, HTML conversions), the overview drowns:

1. **ID shrapnel wins TF-IDF.** Dashed GUIDs (`AB12CD34-5678-4EFA-…`) slip past the existing `[a-f0-9]{8,}` filter because hyphens split them into short fragments ("dab", "bcf"). Each fragment is note-unique, so TF-IDF scores it as highly distinctive — the algorithm structurally rewards garbage.
2. **Folder fans dominate the map.** Hundreds of near-identical converted-document folders render one line each, burying the curated structure (on the worst benchmarked vault, ~230 of 242 lines were import folders).

Noise keywords aren't just wasted tokens — they prime the agent to *search in noise terms*.

## Fix

**Structured-noise stripping (always on).** `stripNoise` now removes GUID/dashed-hex runs, digit-mixed ID blobs, HTML tags/entities, and long hex-letter runs *before* tokenization. A token-level "wordness" filter was tried and rejected — it killed real vocabulary (`pdf`, `xlsx`, `fee`). You can't judge a 3-letter token; you can recognize a GUID in context.

**Homogeneous-sibling collapse (`overview.collapse` config, default `true`).** Parents with ≥5 children whose mean pairwise term-distribution cosine ≥ 0.15 render as one aggregate row: `contracts/ (+153 similar subfolders)`. Similarity is computed over **body+heading terms only** — shared naming conventions can't fake content homogeneity — and the vault root is never a collapse target (top-level folders are the taxonomy). `--no-collapse` restores the full listing; JSON gains an additive `collapsedFolders` field.

**Warnings → stderr.** Previously a single malformed-frontmatter note corrupted `overview --json` stdout.

## Results (benchmark on 8 real-world agent vaults)

| | worst-polluted vault | large mixed vault | 4 clean vaults |
|---|---|---|---|
| overview lines | 242 → **11** | 396 → **24** | unchanged |
| noise keywords leaked | 778 → **6** | 884 → **11** | 0 → 0 |
| curated-keyword robustness* | 0.71 → **0.82** | 0.78 → **0.92** | 1.0 → 1.0 |

\* recall of the keywords the same algorithm produces when import subtrees are excluded — i.e. how well pollution is prevented from corrupting curated folders' keywords.

Interactions that shaped the design: collapse is useless without noise-stripping (ID shrapnel makes dump folders look *different from each other*, blocking collapse); note-level IDF was evaluated and rejected (marginal residual gain, measurable recall cost). The 0.15 threshold sits on a plateau — 0.125–0.175 produce identical collapse sets, and no curated folder collapses even at 0.10.

## Notes

- No folder-name blacklists anywhere: anything statistically shaped like a repetitive document dump collapses; anything curated is untouchable by construction.
- CLI contract preserved: JSON shape extended additively; human output adds a `(+N similar subfolders)` marker.
- Tests: 358 pass, including new coverage for GUID stripping, collapse, root guard, heterogeneous-sibling preservation, and `--no-collapse`.
